### PR TITLE
Fix dependency name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ source files.
 Add the following to your Mix dependencies:
 
 ```elixir
-{:alpaca_lib, git: "https://github.com/lepoetemaudit/alpaca_mix_compiler", branch: "master"}
+{:alpaca_compiler, git: "https://github.com/lepoetemaudit/alpaca_mix_compiler", branch: "master"}
 ```
 
 Ensure it is added as a compiler in your project definition:
@@ -21,7 +21,7 @@ compilers: Mix.compilers ++ [:alpaca],
 
 You may need to add an explicit reference to epo_runtime in your Mix.lock file;
 the API for this is changing and doesn't return expect results, so error
-messages may not show up correctly unless you do this. 
+messages may not show up correctly unless you do this.
 
 ```elixir
 "epo_runtime": {:git, "git://github.com/brigadier/epo_runtime.git", "a3e50e7cebb526f833757e867bbe914c1da7baa3", [tag: "0.3"]}


### PR DESCRIPTION
When plugin is installed using `:alpaca_lib` it is downloaded properly, but it cannot be started by Mix, because `alpaca_lib.app` can't be found. Thus it needs to be installed as `:alpaca_compiler`.